### PR TITLE
Adding Private and Public declarations before ending module

### DIFF
--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -74,15 +74,17 @@ class Refactor:
             f"    {add_kind(v)} {v}" for v in variables)
 
         new = f"""
-module {self.block_name}
-    !> Arguments: {variable_names}
-    use precision_kinds, only: dp
-    include 'vmc.h'
+ module {self.block_name}
+   !> Arguments: {variable_names}
+   use precision_kinds, only: dp
+   include 'vmc.h'
 
 {kinds_and_variables}
 
+    private 
+    public :: {variable_names} 
     save
-end module {self.block_name}
+ end module {self.block_name}
 """
         return new
 


### PR DESCRIPTION
This PR adds the private and public statement printing at the end of the module call. Eg. on output:

- Before: 

```
module grdntsmv
   !> Arguments: igrdaidx, igrdcidx, igrdmv
   use precision_kinds, only: dp
   include 'vmc.h'

    integer  :: igrdaidx(MFORCE)
    integer  :: igrdcidx(MFORCE)
    integer  :: igrdmv(3,MCENT)
 
    save
end module grdntsm
```

- Now: 

```
 module grdntsmv
   !> Arguments: igrdaidx, igrdcidx, igrdmv
   use precision_kinds, only: dp
   include 'vmc.h'

    integer  :: igrdaidx(MFORCE)
    integer  :: igrdcidx(MFORCE)
    integer  :: igrdmv(3,MCENT)

    private 
    public :: igrdaidx, igrdcidx, igrdmv 
    save
 end module grdntsmv
```