### PR TITLE
Adding IMPLICIT REAL (in caps) to change_subroutine function.

### DIFF
--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -168,8 +168,13 @@ end module {self.block_name}
             before_implicit, after_implicit = split_str_at_keyword(
                 "implicit real.*", xs)
         except AttributeError:
-            before_implicit, after_implicit = split_str_at_keyword(
+            try:
+             before_implicit, after_implicit = split_str_at_keyword(
                 "implicit double.*", xs)
+            except:
+             before_implicit, after_implicit = split_str_at_keyword(
+                "IMPLICIT REAL.*", xs)
+
 
         # search and removed common block
         before_common, after_common = split_str_at_keyword(

--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -171,6 +171,9 @@ end module {self.block_name}
             try:
              before_implicit, after_implicit = split_str_at_keyword(
                 "implicit double.*", xs)
+            except AttributeError:
+             before_implicit, after_implicit = split_str_at_keyword(
+                "implicit none.*", xs)
             except:
              before_implicit, after_implicit = split_str_at_keyword(
                 "IMPLICIT REAL.*", xs)


### PR DESCRIPTION
The IMPLICIT REAL statement sometimes appears in capital letters, therefore refactor.py fails at split_str_at_keyword()

This PR fixes the issue.  