### PR TITLE
Adding exceptions 'implicit none' and 'IMPLICIT REAL'  to the ch…

### DIFF
--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -163,22 +163,23 @@ class Refactor:
 
         return components
 
-    def change_subroutine(self, module_call: str, xs: str) -> str:
+   def change_subroutine(self, module_call: str, xs: str) -> str:
         """Replace common block in subroutine."""
         # Search and removed implicit
         try:
             before_implicit, after_implicit = split_str_at_keyword(
                 "implicit real.*", xs)
         except AttributeError:
-            try:
-             before_implicit, after_implicit = split_str_at_keyword(
+          try: 
+            before_implicit, after_implicit = split_str_at_keyword(
                 "implicit double.*", xs)
-            except AttributeError:
-             before_implicit, after_implicit = split_str_at_keyword(
-                "implicit none.*", xs)
-            except:
-             before_implicit, after_implicit = split_str_at_keyword(
+          except AttributeError:
+            try: 
+              before_implicit, after_implicit = split_str_at_keyword(
                 "IMPLICIT REAL.*", xs)
+            except AttributeError:
+              before_implicit, after_implicit = split_str_at_keyword(
+                "implicit none.*", xs)
 
         # search and removed common block
         before_common, after_common = split_str_at_keyword(

--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -163,7 +163,7 @@ class Refactor:
 
         return components
 
-   def change_subroutine(self, module_call: str, xs: str) -> str:
+    def change_subroutine(self, module_call: str, xs: str) -> str:
         """Replace common block in subroutine."""
         # Search and removed implicit
         implicits = [ "none",  "double", "real"]

--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -170,8 +170,15 @@ class Refactor:
             before_implicit, after_implicit = split_str_at_keyword(
                 "implicit real.*", xs)
         except AttributeError:
-            before_implicit, after_implicit = split_str_at_keyword(
+            try:
+             before_implicit, after_implicit = split_str_at_keyword(
                 "implicit double.*", xs)
+            except AttributeError:
+             before_implicit, after_implicit = split_str_at_keyword(
+                "implicit none.*", xs)
+            except:
+             before_implicit, after_implicit = split_str_at_keyword(
+                "IMPLICIT REAL.*", xs)
 
         # search and removed common block
         before_common, after_common = split_str_at_keyword(


### PR DESCRIPTION
_split_str_at_keyword()_ fails because the 'IMPLICIT REAL' statement sometimes appears in capital letters or the subroutine uses an 'implicit none' instead. 

Both issues are fixed in this PR. 