### PR TITLE
Fix search _for_procedures to be END-enD-end case insensitive.

### DIFF
--- a/refac/refactor.py
+++ b/refac/refactor.py
@@ -25,7 +25,7 @@ def search_for_procedures(index: int, xs: str, procedure: str = "subroutine") ->
     """Search for string slice containing the procedure."""
     start = re.search(f"      {procedure}", xs[index:])
     if start is not None:
-        end = re.search(r"      end\s*\n", xs[index + start.start():])
+        end = re.search(r"(?i)      end\s*\n", xs[index + start.start():])
         return index + start.start(), index + start.start() + end.end()
     else:
         return None


### PR DESCRIPTION
Hi @felipeZ,

Sometimes subroutines end with an 'END' in capital letters. The one-line modification of this PR fix the issue. 